### PR TITLE
Implement some stub functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,3 @@
-lib-cov
-*.seed
-*.log
-*.csv
-*.dat
-*.out
-*.pid
-*.gz
-
-pids
-logs
-results
-
-npm-debug.log
+node_modules/
+*.js
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -1,27 +1,103 @@
+function sysinfo() {
+  const struct = Memory.alloc(128);
+  if (new NativeFunction(Module.getExportByName(null, "sysinfo"), "int", ["pointer"])(struct) === 0) {
+    const uptime = struct.readLong();
+    const totalram = struct.add(Process.pointerSize * 4).readULong(); // long should be equal to pointer size
+    const freeram = struct.add(Process.pointerSize * 5).readULong();
+    return [uptime, totalram, freeram];
+  }
+  return [undefined, undefined, undefined];
+}
+
+function globalMemoryStatus() {
+  const struct = Memory.alloc(64);
+  struct.writeU32(64);
+  if (new NativeFunction(Module.getExportByName("kernel32.dll", "GlobalMemoryStatusEx"), "int", ["pointer"])(struct)) {
+    const totalPhys = struct.add(8).readULong();
+    const availPhys = struct.add(16).readULong();
+    return [totalPhys, availPhys];
+  }
+  return [undefined, undefined];
+}
+
 export function endianness() {
   const buf = Memory.alloc(4);
   buf.writeU32(1);
-  return (buf.readU8() === 1) ? 'LE' : 'BE';
+  return buf.readU8() === 1 ? "LE" : "BE";
 }
 
 export function hostname() {
-  return '';
+  switch (Process.platform) {
+    case "windows":
+    case "linux":
+      const limit = Process.platform === "linux" ? 256 : 16;
+      const buffer = Memory.alloc(limit);
+      if (new NativeFunction(Module.getExportByName(null, "gethostname"), "int", ["pointer", "int"])(buffer, limit) === 0) return buffer.readUtf8String() ?? "";
+      else return "";
+    case "darwin":
+    case "freebsd":
+    case "qnx":
+    case "barebone":
+      return "";
+  }
 }
 
 export function loadavg() {
-  return [0, 0, 0];
+  switch (Process.platform) {
+    case "linux":
+      const buffer = Memory.alloc(3 * 8);
+      if (new NativeFunction(Module.getExportByName(null, "getloadavg"), "int", ["pointer", "int"])(buffer, 3) === 3)
+        return [buffer.readDouble(), buffer.add(8).readDouble(), buffer.add(16).readDouble()];
+      return [0, 0, 0];
+    case "freebsd":
+    case "qnx":
+    case "barebone":
+    case "windows": // Windows doesn't support loadavg
+    case "darwin":
+      return [0, 0, 0];
+  }
 }
 
 export function uptime() {
-  return 0;
+  switch (Process.platform) {
+    case "linux":
+      return sysinfo()[0] ?? 0;
+    case "windows":
+      return new NativeFunction(Module.getExportByName(null, "GetTickCount64"), "uint64", [])() / 1000;
+    case "freebsd":
+    case "qnx":
+    case "barebone":
+    case "darwin":
+      return 0;
+  }
 }
 
 export function freemem() {
-  return Number.MAX_VALUE;
+  switch (Process.platform) {
+    case "linux":
+      return sysinfo()[2] ?? Number.MAX_VALUE;
+    case "windows":
+      return globalMemoryStatus()[1] ?? Number.MAX_VALUE;
+    case "darwin":
+    case "freebsd":
+    case "qnx":
+    case "barebone":
+      return Number.MAX_VALUE;
+  }
 }
 
 export function totalmem() {
-  return Number.MAX_VALUE;
+  switch (Process.platform) {
+    case "linux":
+      return sysinfo()[1] ?? Number.MAX_VALUE;
+    case "windows":
+      return globalMemoryStatus()[0] ?? Number.MAX_VALUE;
+    case "freebsd":
+    case "qnx":
+    case "barebone":
+    case "darwin":
+      return 0;
+  }
 }
 
 export function cpus() {
@@ -30,13 +106,35 @@ export function cpus() {
 
 export function type() {
   const p = Process.platform;
-  if (p === 'windows')
-    return 'Windows_NT';
+  if (p === "windows") return "Windows_NT";
   return p[0].toUpperCase() + p.substr(1);
 }
 
 export function release() {
-  return '';
+  switch (Process.platform) {
+    case "linux":
+      const struct = Memory.alloc(512);
+      if (new NativeFunction(Module.getExportByName(null, "uname"), "int", ["pointer"])(struct) === 0) {
+        const offsets = [9, 33, 65, 257];
+        let hostnameOffset = 0;
+
+        for (const offset of offsets) {
+          const str = struct.add(offset).readCString();
+          if (str && str.length > 5) {
+            hostnameOffset = offset;
+            break;
+          }
+        }
+        return struct.add(hostnameOffset * 2).readCString() ?? "";
+      }
+      return "";
+    case "windows":
+    case "freebsd":
+    case "qnx":
+    case "barebone":
+    case "darwin":
+      return "";
+  }
 }
 
 export function networkInterfaces() {
@@ -53,8 +151,7 @@ export function arch() {
 
 export function platform() {
   const p = Process.platform;
-  if (p === 'windows')
-    return 'win32';
+  if (p === "windows") return "win32";
   return p;
 }
 
@@ -62,7 +159,7 @@ export function tmpdir() {
   return Process.getTmpDir();
 }
 
-export const EOL = (Process.platform === 'windows') ? '\r\n' : '\n';
+export const EOL = Process.platform === "windows" ? "\r\n" : "\n";
 
 export function homedir() {
   return Process.getHomeDir();
@@ -84,5 +181,5 @@ export default {
   platform,
   tmpdir,
   EOL,
-  homedir,
+  homedir
 };

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ export function release() {
 
         for (const offset of offsets) {
           const str = struct.add(offset).readCString();
-          if (str && str.length > 5) {
+          if (str) {
             hostnameOffset = offset;
             break;
           }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/frida/gumjs-os.git"
+  },
+  "devDependencies": {
+    "@types/frida-gum": "^18.7.0"
   }
 }


### PR DESCRIPTION
Implemented `hostname`, `loadavg` (linux-based only), `uptime`, `freemem`, `totalmem`, `release` (linux-based only) for Linux (including Android) and Windows (except mentioned "linux-based only")

tested with:
```
import * as os from "./index.js";
console.log("endianness:", os.endianness());
console.log("hostname:", os.hostname());
console.log("loadavg:", os.loadavg());
console.log("uptime:", os.uptime());
console.log("freemem:", os.freemem());
console.log("totalmem:", os.totalmem());
console.log("cpus:", os.cpus());
console.log("type:", os.type());
console.log("release:", os.release());
console.log("networkInterfaces:", os.networkInterfaces());
console.log("getNetworkInterfaces:", os.getNetworkInterfaces());
console.log("arch:", os.arch());
console.log("platform:", os.platform());
console.log("tmpdir:", os.tmpdir());
console.log("EOL:", os.EOL);
console.log("homedir:", os.homedir());
```

Expected output on linux:
```
endianness: LE
hostname: laptop
loadavg: 2.81103515625,3.24951171875,3.1689453125
uptime: 9945
freemem: 1840672768
totalmem: 8143245312
cpus:
type: Linux
release: 6.10.10-zen1-1-zen
networkInterfaces: [object Object]
getNetworkInterfaces: [object Object]
arch: x64
platform: linux
tmpdir: /tmp
EOL:

homedir: /home/commonuserlol
```

Expected output on Android:
```
endianness: LE
hostname: localhost
loadavg: 25.8623046875,26.13671875,26.171875
uptime: 165415
freemem: 106717184
totalmem: 3928104960
cpus:
type: Linux
release: 4.14.352
networkInterfaces: [object Object]
getNetworkInterfaces: [object Object]
arch: arm
platform: linux
tmpdir: /tmp
EOL:

homedir: /data
```